### PR TITLE
test: Playwright E2E 移行前ベースラインを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ _ProjectList/
 
 # Playwright MCP temporary files
 .playwright-mcp/
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// 移行前の現状を固定する特性テスト（デフォルト言語 en）。
+// 各ルートについて「HTTP 200 で応答」「共通ナビ（Header）が描画」
+// 「ルート固有のテキストが表示」を確認する。
+// リファクタ後もこれらが緑であれば、表示の回帰は起きていないとみなす。
+
+type Route = {
+  name: string;
+  path: string;
+  marker: RegExp;
+};
+
+// マーカーはヒーロー見出し（H1 は1文字ずつ span 分割されるため getByText で
+// 全文一致できない）を避け、非分割の安定テキスト（サブタイトル・ラベル等）を使う。
+const routes: Route[] = [
+  { name: 'home', path: '/', marker: /Software Engineer & UI\/UX Designer/i },
+  { name: 'software 一覧', path: '/software', marker: /Core Expertise/i },
+  {
+    name: 'software 詳細 (techdoctor)',
+    path: '/software/techdoctor',
+    marker: /Digital Biomarker Development Platform/i,
+  },
+  { name: 'uiux 一覧', path: '/uiux', marker: /Turning ideas into beautiful experiences/i },
+  {
+    name: 'uiux 詳細 (achievy)',
+    path: '/uiux/achievy',
+    marker: /Task Management App for ADHD Students/i,
+  },
+  { name: 'contact', path: '/contact', marker: /@kyokozuka/i },
+];
+
+for (const route of routes) {
+  test(`${route.name} (${route.path}) が現状どおり描画される`, async ({ page }) => {
+    const response = await page.goto(route.path);
+    expect(response?.status(), 'HTTP ステータス').toBeLessThan(400);
+
+    // 共通ナビ（Header）が存在する = レイアウトが壊れていない
+    // 詳細ページは「戻る」ナビ等で navigation role が複数あるため first を見る
+    await expect(page.getByRole('navigation').first()).toBeVisible();
+
+    // ルート固有のテキストが表示される
+    await expect(page.getByText(route.marker).first()).toBeVisible();
+  });
+}

--- a/mise.toml
+++ b/mise.toml
@@ -34,3 +34,7 @@ run = "npm start"
 [tasks."test"]
 description = "Run unit tests (Vitest)"
 run = "npm test"
+
+[tasks."e2e"]
+description = "Run E2E tests (Playwright)"
+run = "npm run e2e"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1273,6 +1274,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6189,6 +6206,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@iconify/react": "^6.0.0",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E は移行前の表示を固定する「特性テスト」。
+// dev サーバに対して実行し、各ルートが崩れていないことを保証する。
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## 概要（Why）

アーキテクチャ再設計（ADR-006 / refactoring_20260711）で大きく動くのはページ・コンポーネント（UI）だが、既存のユニットテストは純粋関数しか覆っておらず UI の回帰を検知できない。移行前の現状表示を固定する E2E ベースライン（特性テスト）を用意し、各 Phase の回帰検知の安全網とする。

## 変更内容（What）

- `@playwright/test` を導入、`playwright.config.ts`（dev サーバ起動・chromium）
- `e2e/routes.spec.ts`: 6ルートの特性テスト（home / software 一覧・詳細 / uiux 一覧・詳細 / contact）
  - 各ルートで「HTTP 200」「共通ナビ（Header）描画」「ルート固有テキスト表示」を検証
  - ヒーロー見出し（H1）は1文字ずつ span 分割されるため、マーカーは非分割の安定テキストを使用
- `npm run e2e` / `mise run e2e` を追加
- `.gitignore` に Playwright 生成物（test-results 等）を追加

## 動作確認

- `npx playwright test`: **6 routes すべて green**
- `type-check` / `lint`: 通過

## 影響範囲

- テスト・開発依存の追加のみ。破壊的変更なし
- 副次的に、`contactData` の "Let's Connect" 等が実際には未描画（死にデータ）であることを検出。SSOT 統一（Phase 5.5）で整理する

## 関連

- ADR-006 / docs/refactoring_20260711.md（本 PR は Phase 0.5 の回帰基盤）