### PR TITLE
feat: Phase 1 i18n 基盤を TDD で追加

### DIFF
--- a/src/content/dictionaries/dictionary.ts
+++ b/src/content/dictionaries/dictionary.ts
@@ -1,0 +1,10 @@
+// UI 文言の辞書の型。ロケール追加・キー追加はこの型で契約を固定し、
+// 各言語ファイルで抜けを型エラーとして検出できるようにする。
+export type Dictionary = {
+  nav: {
+    home: string;
+    software: string;
+    uiux: string;
+    contact: string;
+  };
+};

--- a/src/content/dictionaries/en.ts
+++ b/src/content/dictionaries/en.ts
@@ -1,0 +1,10 @@
+import type { Dictionary } from './dictionary';
+
+export const en: Dictionary = {
+  nav: {
+    home: 'Home',
+    software: 'Software',
+    uiux: 'UI/UX',
+    contact: 'Contact',
+  },
+};

--- a/src/content/dictionaries/ja.ts
+++ b/src/content/dictionaries/ja.ts
@@ -1,0 +1,10 @@
+import type { Dictionary } from './dictionary';
+
+export const ja: Dictionary = {
+  nav: {
+    home: 'ホーム',
+    software: 'ソフトウェア',
+    uiux: 'UI/UX',
+    contact: 'お問い合わせ',
+  },
+};

--- a/src/lib/get-dictionary.test.ts
+++ b/src/lib/get-dictionary.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { getDictionary } from './get-dictionary';
+
+describe('getDictionary', () => {
+  it('en の辞書を返す', () => {
+    const dict = getDictionary('en');
+    expect(dict.nav.home).toBe('Home');
+    expect(dict.nav.contact).toBe('Contact');
+  });
+
+  it('ja の辞書を返す', () => {
+    const dict = getDictionary('ja');
+    expect(dict.nav.home).toBe('ホーム');
+    expect(dict.nav.contact).toBe('お問い合わせ');
+  });
+
+  it('全ロケールで nav の全キーが揃っている', () => {
+    for (const locale of ['en', 'ja'] as const) {
+      const nav = getDictionary(locale).nav;
+      expect(Object.keys(nav).sort()).toEqual(['contact', 'home', 'software', 'uiux']);
+    }
+  });
+});

--- a/src/lib/get-dictionary.ts
+++ b/src/lib/get-dictionary.ts
@@ -1,0 +1,13 @@
+import type { Locale } from './i18n';
+import { defaultLocale } from './i18n';
+import type { Dictionary } from '@/content/dictionaries/dictionary';
+import { en } from '@/content/dictionaries/en';
+import { ja } from '@/content/dictionaries/ja';
+
+const dictionaries: Record<Locale, Dictionary> = { en, ja };
+
+// ロケールに対応する辞書を返す。静的なコンテンツのため同期で解決する。
+// 想定外の値には defaultLocale の辞書でフォールバックする。
+export function getDictionary(locale: Locale): Dictionary {
+  return dictionaries[locale] ?? dictionaries[defaultLocale];
+}

--- a/src/lib/i18n.test.ts
+++ b/src/lib/i18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { locales, defaultLocale, isLocale } from './i18n';
+
+describe('locales / defaultLocale', () => {
+  it('en と ja をサポートする', () => {
+    expect(locales).toContain('en');
+    expect(locales).toContain('ja');
+  });
+
+  it('デフォルトロケールは en', () => {
+    expect(defaultLocale).toBe('en');
+  });
+});
+
+describe('isLocale', () => {
+  it('サポートするロケールは true', () => {
+    expect(isLocale('en')).toBe(true);
+    expect(isLocale('ja')).toBe(true);
+  });
+
+  it('未対応の値は false', () => {
+    expect(isLocale('fr')).toBe(false);
+    expect(isLocale('')).toBe(false);
+    expect(isLocale('EN')).toBe(false);
+  });
+});

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,12 @@
+// サポートするロケール定義。ロケールルーティング（app/[lang]）と
+// 辞書ロードの単一ソース。middleware を使わない静的書き出し前提のため、
+// generateStaticParams はこの locales を返す。
+export const locales = ['en', 'ja'] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = 'en';
+
+export function isLocale(value: string): value is Locale {
+  return (locales as readonly string[]).includes(value);
+}


### PR DESCRIPTION
## 概要（Why）

ADR-006 / refactoring_20260711 の Phase 1。ロケールルーティング（`app/[lang]`）と辞書ロードの土台を、ルーティング非依存の純粋ロジックとして先に用意する。壊れている `useLanguage`（ローカル state・伝播しない）を置き換える基盤で、Phase 2 で利用する。

## 変更内容（What）

- `src/lib/i18n.ts`: `locales`(['en','ja']) / `Locale` 型 / `defaultLocale` / `isLocale` ガード
- `src/content/dictionaries/{dictionary,en,ja}.ts`: `Dictionary` 型と en/ja の UI 文言（現行 `getNavText` の内容を移設）
- `src/lib/get-dictionary.ts`: `getDictionary(locale)` ローダ（同期・defaultLocale フォールバック）
- **TDD**: テスト先行で実装。ユニットテスト7件を追加（`i18n.test.ts` / `get-dictionary.test.ts`）

## 動作確認

- `mise run test`: 5 files / 24 tests すべて green（既存17 + 新規7）
- `mise run type-check` / `mise run lint`: 通過
- ルーティング非依存の基盤のため UI 変更なし（E2E は現状維持で緑）

## 影響範囲

- 追加のみ。既存挙動への影響なし（まだ app からは未使用。Phase 2 で配線）
- 型で辞書の契約を固定し、ロケール/キー追加時の抜けを型エラーで検出できる

## 関連

- ADR-006 / docs/refactoring_20260711.md（Phase 1）