### PR TITLE
fix: 再利用セクション内の旧ロケール無しリンクを修正

### DIFF
--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -63,3 +63,22 @@ for (const path of jaRoutes) {
     await expect(page.getByText(/ソフトウェア/).first()).toBeVisible();
   });
 }
+
+// 内部リンクがロケール無しの旧パス（/software 等）を指していないこと（リンク切れ回帰防止）。
+const linkAuditPaths = [
+  '/en',
+  '/en/software',
+  '/en/software/techdoctor',
+  '/en/uiux',
+  '/en/uiux/achievy',
+  '/en/contact',
+];
+for (const p of linkAuditPaths) {
+  test(`${p} に旧ロケール無しパスへの内部リンクが無い`, async ({ page }) => {
+    await page.goto(p);
+    const stale = await page
+      .locator('a[href^="/software"], a[href^="/uiux"], a[href^="/contact"]')
+      .evaluateAll((els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href')));
+    expect(stale, `旧パスリンク: ${stale.join(', ')}`).toEqual([]);
+  });
+}

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -25,11 +25,11 @@ export default async function Home({ params }: { params: Promise<{ lang: string 
       <Header lang={lang} />
 
       <main>
-        <HomeHeroSection currentContent={currentContent} isLoaded={true} />
+        <HomeHeroSection currentContent={currentContent} isLoaded={true} lang={lang} />
         <HomeAchievementsSection achievements={currentContent.achievements} />
-        <HomeRoleCardsSection software={currentContent.software} uiux={currentContent.uiux} />
+        <HomeRoleCardsSection software={currentContent.software} uiux={currentContent.uiux} lang={lang} />
         <HomeAboutSection about={currentContent.about} />
-        <HomeProjectsSection highlights={currentContent.highlights} />
+        <HomeProjectsSection highlights={currentContent.highlights} lang={lang} />
       </main>
 
       <Footer />

--- a/src/app/[lang]/software/page.tsx
+++ b/src/app/[lang]/software/page.tsx
@@ -50,7 +50,7 @@ export default async function SoftwarePage({ params }: { params: Promise<{ lang:
           title={currentContent.projects.title}
           currentLang={lang}
         />
-        <ContactSection />
+        <ContactSection lang={lang} />
       </main>
 
       <Footer />

--- a/src/app/[lang]/uiux/page.tsx
+++ b/src/app/[lang]/uiux/page.tsx
@@ -42,10 +42,10 @@ export default async function UIUXPage({ params }: { params: Promise<{ lang: str
           isLoaded={true}
         />
         <UIUXSkillsSection skillsByCategory={skillsByCategory} />
-        <UIUXProjectsSection projects={uiuxProjects} />
+        <UIUXProjectsSection projects={uiuxProjects} lang={lang} />
         <UIUXExperienceSection experience={uiuxExperience} />
         <UIUXAcademicProjectsSection academicProjects={uiuxAcademicProjects} />
-        <UIUXContactSection contactText={currentContent.contact} />
+        <UIUXContactSection contactText={currentContent.contact} lang={lang} />
       </main>
 
       <Footer />

--- a/src/features/home/ui/HomeHeroSection.tsx
+++ b/src/features/home/ui/HomeHeroSection.tsx
@@ -6,9 +6,10 @@ import { HomeContent } from '@/features/home/data';
 interface HomeHeroSectionProps {
   currentContent: HomeContent;
   isLoaded: boolean; // kept for interface compatibility, animation is CSS-driven
+  lang: string;
 }
 
-export default function HomeHeroSection({ currentContent }: HomeHeroSectionProps) {
+export default function HomeHeroSection({ currentContent, lang }: HomeHeroSectionProps) {
   return (
     <section aria-labelledby="hero-heading" className="max-w-7xl mx-auto px-6 lg:px-12 pt-28 pb-24 md:pt-36 md:pb-32">
       <div className="max-w-4xl">
@@ -46,13 +47,13 @@ export default function HomeHeroSection({ currentContent }: HomeHeroSectionProps
         {/* CTAs */}
         <div className="hero-l4 flex flex-wrap gap-4">
           <Link
-            href="/software"
+            href={`/${lang}/software`}
             className="font-body font-medium text-sm px-8 py-3.5 bg-ink text-canvas hover:bg-accent transition-colors duration-200"
           >
             Software Work
           </Link>
           <Link
-            href="/uiux"
+            href={`/${lang}/uiux`}
             className="font-body font-medium text-sm px-8 py-3.5 border border-ink text-ink hover:border-accent hover:text-accent transition-colors duration-200"
           >
             Design Work

--- a/src/features/home/ui/HomeProjectsSection.tsx
+++ b/src/features/home/ui/HomeProjectsSection.tsx
@@ -6,9 +6,10 @@ import { useReveal } from '@/lib/hooks';
 
 interface HomeProjectsSectionProps {
   highlights: HomeContent['highlights'];
+  lang: string;
 }
 
-export default function HomeProjectsSection({ highlights }: HomeProjectsSectionProps) {
+export default function HomeProjectsSection({ highlights, lang }: HomeProjectsSectionProps) {
   const { ref, visible } = useReveal<HTMLElement>();
 
   return (
@@ -59,7 +60,7 @@ export default function HomeProjectsSection({ highlights }: HomeProjectsSectionP
             ))}
           </ul>
           <Link
-            href="/software"
+            href={`/${lang}/software`}
             className="font-body text-sm font-medium text-ink-muted hover:text-accent transition-colors duration-200 inline-flex items-center gap-2 mt-8"
           >
             All software work <span aria-hidden="true">→</span>
@@ -91,7 +92,7 @@ export default function HomeProjectsSection({ highlights }: HomeProjectsSectionP
             ))}
           </ul>
           <Link
-            href="/uiux"
+            href={`/${lang}/uiux`}
             className="font-body text-sm font-medium text-ink-muted hover:text-accent transition-colors duration-200 inline-flex items-center gap-2 mt-8"
           >
             All design work <span aria-hidden="true">→</span>

--- a/src/features/home/ui/HomeRoleCardsSection.tsx
+++ b/src/features/home/ui/HomeRoleCardsSection.tsx
@@ -7,14 +7,15 @@ import { useReveal } from '@/lib/hooks';
 interface HomeRoleCardsSectionProps {
   software: HomeContent['software'];
   uiux: HomeContent['uiux'];
+  lang: string;
 }
 
-export default function HomeRoleCardsSection({ software, uiux }: HomeRoleCardsSectionProps) {
+export default function HomeRoleCardsSection({ software, uiux, lang }: HomeRoleCardsSectionProps) {
   const { ref, visible } = useReveal<HTMLElement>();
 
   const cards = [
-    { data: software, href: '/software', num: '01' },
-    { data: uiux,     href: '/uiux',     num: '02' },
+    { data: software, href: `/${lang}/software`, num: '01' },
+    { data: uiux,     href: `/${lang}/uiux`,     num: '02' },
   ];
 
   return (

--- a/src/features/software/ui/ContactSection.tsx
+++ b/src/features/software/ui/ContactSection.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useReveal } from "@/lib/hooks";
 
-export default function ContactSection() {
+export default function ContactSection({ lang }: { lang: string }) {
   const { ref, visible } = useReveal<HTMLElement>();
 
   return (
@@ -22,7 +22,7 @@ export default function ContactSection() {
           <em>something great.</em>
         </h2>
         <Link
-          href="/contact"
+          href={`/${lang}/contact`}
           className="font-body font-medium text-sm px-8 py-3.5 bg-ink text-canvas hover:bg-accent transition-colors duration-200 inline-block"
         >
           Get in touch

--- a/src/features/software/ui/FeaturedProjects.tsx
+++ b/src/features/software/ui/FeaturedProjects.tsx
@@ -41,7 +41,7 @@ export default function FeaturedProjects({ projects, title, currentLang }: Featu
               style={{ transitionDelay: `${(i + 1) * 80}ms` }}
             >
               <Link
-                href={`/software/${project.id}`}
+                href={`/${currentLang}/software/${project.id}`}
                 className="grid grid-cols-12 gap-4 py-8 group"
               >
                 <div className="col-span-12 md:col-span-3">

--- a/src/features/software/ui/SoftwareProjectPage.tsx
+++ b/src/features/software/ui/SoftwareProjectPage.tsx
@@ -235,7 +235,8 @@ export default function SoftwareProjectPage({ projectData, lang }: SoftwareProje
               </Link>
               {currentData.nextProjectLink && (
                 <Link
-                  href={currentData.nextProjectLink}
+                  // nextProjectLink はロケール無しの相対パス（例 /software/ecommerce）。ロケールを前置する。
+                  href={`/${lang}${currentData.nextProjectLink}`}
                   className="font-body text-sm text-ink-muted hover:text-accent transition-colors duration-200 inline-flex items-center gap-2"
                 >
                   {currentData.nextProject} <span aria-hidden="true">→</span>

--- a/src/features/uiux/ui/UIUXContactSection.tsx
+++ b/src/features/uiux/ui/UIUXContactSection.tsx
@@ -5,9 +5,10 @@ import { useReveal } from '@/lib/hooks';
 
 interface UIUXContactSectionProps {
   contactText: string;
+  lang: string;
 }
 
-export default function UIUXContactSection({ contactText }: UIUXContactSectionProps) {
+export default function UIUXContactSection({ contactText, lang }: UIUXContactSectionProps) {
   const { ref, visible } = useReveal<HTMLElement>();
 
   return (
@@ -26,7 +27,7 @@ export default function UIUXContactSection({ contactText }: UIUXContactSectionPr
           <em>Let&apos;s design together.</em>
         </h2>
         <Link
-          href="/contact"
+          href={`/${lang}/contact`}
           className="font-body font-medium text-sm px-8 py-3.5 bg-ink text-canvas hover:bg-accent transition-colors duration-200 inline-block"
         >
           Start a project

--- a/src/features/uiux/ui/UIUXProjectsSection.tsx
+++ b/src/features/uiux/ui/UIUXProjectsSection.tsx
@@ -7,9 +7,10 @@ import { useReveal } from '@/lib/hooks';
 
 interface UIUXProjectsSectionProps {
   projects: UIUXProject[];
+  lang: string;
 }
 
-export default function UIUXProjectsSection({ projects }: UIUXProjectsSectionProps) {
+export default function UIUXProjectsSection({ projects, lang }: UIUXProjectsSectionProps) {
   const { ref, visible } = useReveal<HTMLElement>();
 
   return (
@@ -36,7 +37,7 @@ export default function UIUXProjectsSection({ projects }: UIUXProjectsSectionPro
             className={`reveal-item border-t border-hairline first:border-t-0 ${visible ? 'visible' : 'hidden'}`}
             style={{ transitionDelay: `${(i + 1) * 100}ms` }}
           >
-            <Link href={`/uiux/${project.id}`} className="group grid grid-cols-12 gap-6 py-10">
+            <Link href={`/${lang}/uiux/${project.id}`} className="group grid grid-cols-12 gap-6 py-10">
 
               {/* Image */}
               <div className="col-span-12 md:col-span-4 lg:col-span-3">


### PR DESCRIPTION
## 概要（Why）

移行（ADR-006 のロケールルーティング化）で UI セクションを再利用したが、**セクション内部のハードコードされた内部リンクが旧パス（`/software`・`/uiux`・`/contact`・`/software/<slug>`）のまま**で、クリックすると 404 になっていた（報告例: `/software/techdoctor`）。既存 E2E は「表示」しか見ておらずリンク切れを検知できていなかった。

## 変更内容（What）

- 各セクションに `lang` を渡し、href を `/[lang]/...` に修正
  - home: `HomeHeroSection` / `HomeProjectsSection` / `HomeRoleCardsSection`
  - software: `FeaturedProjects` / `ContactSection` / `SoftwareProjectPage`
  - uiux: `UIUXProjectsSection` / `UIUXContactSection`
- `SoftwareProjectPage` の `nextProjectLink`（YAML データがロケール無しの相対パス）は `/${lang}` を前置して解決
- **回帰防止**: E2E に「各ページに旧ロケール無しの内部リンクが無い」監査テストを追加（6ルート）

## 動作確認

- `build` / `type-check` / `lint` / `test`(10) / `e2e`(17: 従来11 + リンク監査6) すべて緑
- 旧パス直リンクの残存ゼロを確認

## 影響範囲

- リンク先の修正のみ。表示は不変
- 今後は E2E のリンク監査で同種の回帰を検知できる

## 関連

- ADR-006 ロケールルーティング移行の後続不具合修正