### PR TITLE
feat: PWA を導入（manifest + アイコン + Service Worker）

### DIFF
--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -82,3 +82,20 @@ for (const p of linkAuditPaths) {
     expect(stale, `旧パスリンク: ${stale.join(', ')}`).toEqual([]);
   });
 }
+
+// PWA: <head> の manifest リンク・theme-color と、アイコン資産の提供を検証する。
+// manifest.webmanifest の中身は静的書き出し（build）で生成されるため内容検証はそちらで担保し、
+// ここでは dev でも確認できるリンク存在・アイコン到達性のみを見る。
+// Service Worker は本番ビルドのみ登録するため E2E(dev) では対象外。
+test('PWA の manifest リンク / theme-color / アイコンが提供される', async ({ page }) => {
+  await page.goto('/en');
+
+  const manifestLink = page.locator('link[rel="manifest"]');
+  await expect(manifestLink).toHaveCount(1);
+  expect(await manifestLink.getAttribute('href')).toContain('manifest.webmanifest');
+
+  await expect(page.locator('meta[name="theme-color"]')).toHaveCount(1);
+
+  const iconRes = await page.request.get('/icon.svg');
+  expect(iconRes.ok()).toBeTruthy();
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,8 @@ const nextConfig: NextConfig = {
   trailingSlash: true,
   basePath: basePath,
   assetPrefix: basePath,
+  // PWA（manifest / Service Worker 登録）で basePath を参照するためクライアントへ公開
+  env: { NEXT_PUBLIC_BASE_PATH: basePath || '' },
   images: {
     unoptimized: true,
     loader: 'default',

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="KY">
+  <rect width="512" height="512" fill="#1A1917"/>
+  <text x="256" y="256" dy="0.34em" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-style="italic" font-weight="600" font-size="248" fill="#F7F5F0">KY</text>
+  <rect x="176" y="372" width="160" height="12" fill="#C8552A"/>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,46 @@
+// シンプルな Service Worker（学習用）。
+// 方針: ナビゲーション/アセットとも「ネットワーク優先・失敗時キャッシュ」。
+// コンテンツサイトなのでオンライン時は常に最新、オフライン時は訪問済みページを表示する。
+const CACHE = 'portfolio-v1';
+
+self.addEventListener('install', () => {
+  // 新しい SW を即時有効化
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      // 旧バージョンのキャッシュを削除
+      const keys = await caches.keys();
+      await Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k)));
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  // 同一オリジンの GET のみ扱う
+  if (request.method !== 'GET' || new URL(request.url).origin !== self.location.origin) return;
+
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE);
+      try {
+        const fresh = await fetch(request);
+        cache.put(request, fresh.clone());
+        return fresh;
+      } catch {
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        // ナビゲーションはキャッシュ済みホームにフォールバック
+        if (request.mode === 'navigate') {
+          const home = await cache.match(`${self.registration.scope}en/`);
+          if (home) return home;
+        }
+        throw new Error('offline and not cached');
+      }
+    })(),
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Cormorant_Garamond, DM_Sans } from "next/font/google";
+import PWARegister from "@/components/pwa-register";
 import "./globals.css";
 
 const cormorant = Cormorant_Garamond({
@@ -22,6 +23,11 @@ export const metadata: Metadata = {
     "Portfolio of Kento Yokozuka — 8+ years building scalable cloud infrastructure and crafting user-centered experiences.",
 };
 
+// PWA: モバイルのアドレスバー等の配色（背景色 canvas に合わせる）
+export const viewport: Viewport = {
+  themeColor: "#F7F5F0",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -31,6 +37,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${cormorant.variable} ${dmSans.variable}`}>
         {children}
+        <PWARegister />
       </body>
     </html>
   );

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next';
+
+// output: 'export' で静的に書き出すため force-static。
+export const dynamic = 'force-static';
+
+const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Kento Yokozuka — Software Engineer & UI/UX Designer',
+    short_name: 'KY Portfolio',
+    description: 'Portfolio of Kento Yokozuka — software engineering and UI/UX design.',
+    start_url: `${base}/en/`,
+    scope: `${base}/`,
+    display: 'standalone',
+    background_color: '#F7F5F0',
+    theme_color: '#F7F5F0',
+    icons: [
+      { src: `${base}/icon.svg`, sizes: 'any', type: 'image/svg+xml', purpose: 'any' },
+      { src: `${base}/icon.svg`, sizes: 'any', type: 'image/svg+xml', purpose: 'maskable' },
+    ],
+  };
+}

--- a/src/components/pwa-register.tsx
+++ b/src/components/pwa-register.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
+
+// Service Worker を登録する葉コンポーネント。
+// 開発時（next dev）はキャッシュ由来の混乱を避けるため本番ビルドのみ登録する。
+export default function PWARegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+    if (!('serviceWorker' in navigator)) return;
+
+    const base = process.env.NEXT_PUBLIC_BASE_PATH || '';
+    navigator.serviceWorker.register(`${base}/sw.js`).catch(() => {
+      // 登録失敗は致命的ではないため握りつぶす
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 概要（Why）

学習も兼ねてポートフォリオを PWA 化する。**同一 URL・同一サイトのまま**、インストール可能にしオフライン閲覧に対応する（別ページ・リダイレクトは不要）。

## 変更内容（What）

- `app/manifest.ts`: Web App Manifest（`display: standalone` / `start_url: /en/` / `theme_color` / アイコン）。`output: export` 用に `force-static`
- `public/icon.svg`: モノグラムアイコン（`any` + `maskable`。globals.css のデザイントークンに準拠）
- `public/sw.js`: Service Worker。ネットワーク優先・失敗時キャッシュ（コンテンツサイト向け。オンラインは常に最新、訪問済みはオフライン表示）
- `components/pwa-register.tsx`: **本番ビルドのみ** SW を登録（dev のキャッシュ混乱を回避）。`basePath` 対応
- `layout.tsx`: `theme-color`（viewport）と `<PWARegister />` を追加
- `next.config.ts`: `NEXT_PUBLIC_BASE_PATH` を公開（GitHub Pages の `/portfolio` basePath 対応）
- E2E: manifest リンク / theme-color / アイコン提供の検証を追加

## 動作確認

- `build`: `out/{manifest.webmanifest, sw.js, icon.svg}` 生成、本番バンドルに SW 登録コードを確認
- `type-check` / `lint` / `test`(10) / `e2e`(18: 従来17 + PWA1) すべて緑
- manifest 内容（standalone / start_url / icons / theme_color）を確認

## 挙動（重要）

- **PC ブラウザ / スマホ ブラウザ: 表示は今のまま**（レスポンシブは別で対応済み）
- 変わるのは「ホーム画面に追加」した時のみ = アプリ風の全画面表示
- 別 URL・別ページへの振り分けは無し

## 影響範囲・注意

- Service Worker は**本番ビルドのみ**登録（`next dev` では無効）。動作確認は `mise run build` + `out/` を配信して行う
- iOS のホーム画面アイコンは PNG（apple-touch-icon）が理想。本 PR は SVG のみ（Android/デスクトップ対応）。必要なら PNG を追加

## 関連

- DESIGN.md（テーマカラー #F7F5F0 = canvas トークン）